### PR TITLE
Fix: Remove multiadd video warning

### DIFF
--- a/views/multi-add.pug
+++ b/views/multi-add.pug
@@ -7,8 +7,6 @@ form(method='POST' action='/../bookmarks/video/multi-add' enctype='multipart/for
             input.form-control(type='file', name='like_list', required)
             br
             button(type='submit', class='form-button form-button_multiadd') Upload List
-            br
-            p Caution: Only works for lists with 250 or fewer videos
         if errors
             ul
             for error in errors


### PR DESCRIPTION
Removed warning about users not being able to add many videos simultaneously.