### PR TITLE
Fix: Video multi-add

### DIFF
--- a/controllers/videoController.js
+++ b/controllers/videoController.js
@@ -494,9 +494,9 @@ exports.video_multiadd_post = function (req, res) {
           newVideo.url = `${newVideo.authorUrl}/video/${newVideo.id}`;
           newVideo.dateAdded = getDateAddedFromTikTokId(newVideo.id);
           sendToLog(logLevel.info, `Video ${queuePosition} processed: ${newVideo.url}`);
-          const isUsersVideosDuplicate = checkUsersVideosForDuplicates(req.user.user_id,
+          const isUsersVideosDuplicate = await checkUsersVideosForDuplicates(req.user.user_id,
             newVideo.id);
-          const isAllVideosDuplicate = checkAllVideosForDuplicates(newVideo.id);
+          const isAllVideosDuplicate = await checkAllVideosForDuplicates(newVideo.id);
           addVideo(isUsersVideosDuplicate, isAllVideosDuplicate, newVideo, req.user.user_id);
         }
         queuePosition += 1;


### PR DESCRIPTION
Issue:
Video multi-add always indicated that videos already
existed within the database, even when they did not.

Fix:
Add await keyword before checking if a video existed.
WIthout the await keyword, we were returning a pending
promise, not the expected Boolean value.

TIK9